### PR TITLE
Fix unbounded issue using _isMounted pattern

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ import {
 } from "react-native";
 
 export default class BouncingPreloader extends Component {
+  _isMounted = false;
   state = {
     spinValue: new Animated.Value(0),
     yValue: new Animated.Value(0),
@@ -21,7 +22,12 @@ export default class BouncingPreloader extends Component {
     iconRight: null
   };
   componentDidMount() {
-    this.changeIndex();
+    if (this._isMounted){
+      this.changeIndex();
+    }
+  }
+  componentWillUnmount() {
+    this._isMounted = false;
   }
   changeIndex() {
     const { currentIndex, icons } = this.state;


### PR DESCRIPTION
This is a solution recommended by Facebook

> Just set a _isMounted property to true in componentDidMount and set it to false in componentWillUnmount, and use this variable to check your component’s status.

This solved [this issue](https://github.com/sonnylazuardi/react-native-bouncing-preloader/issues/4)