### PR TITLE
Added missing parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,18 +53,21 @@ export default class BouncingPreloader extends Component {
     Animated.timing(this.state.spinValue, {
       toValue: 1,
       duration: this.props.speed * 2,
-      easing: Easing.linear
+      easing: Easing.linear,
+      useNativeDriver: true
     }).start();
     Animated.timing(this.state.yValue, {
       toValue: 1,
       duration: this.props.speed / 2,
-      easing: Easing.bezier(0, 1, 1, 1)
+      easing: Easing.bezier(0, 1, 1, 1),
+      useNativeDriver: true
     }).start(() => {
       Animated.timing(this.state.yValue, {
         delay: 5,
         toValue: 0,
         duration: this.props.speed / 2,
-        easing: Easing.bezier(1, 0, 1, 1)
+        easing: Easing.bezier(1, 0, 1, 1),
+        useNativeDriver: true
       }).start(() => {
         setTimeout(() => {
           callback && callback();


### PR DESCRIPTION
## Why

The `useNativeDriver` is currently required, and it was missing from the index file.

Here's the warning shown for this package without this parameter set:
```
 WARN     Animated: `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false` 
```

## Changes
I added the missing parameter to the `index.js` file. I set the param to `true` which is the recommended setting for animations that do not need user interactions.

## P.S.
This bouncing animation is so cute! Thank you for creating it 🤗 